### PR TITLE
Replace react-reveal with framer-motion animations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "colorthief": "^2.3.0",
-        "framer-motion": "^4.1.17",
+        "framer-motion": "^5.6.0",
         "gh-pages": "^2.2.0",
         "i18next": "^20.1.0",
         "react": "^16.10.2",
@@ -18,7 +18,6 @@
         "react-headroom": "^3.0.0",
         "react-i18next": "^11.8.12",
         "react-lottie": "^1.2.3",
-        "react-reveal": "^1.2.2",
         "react-scripts": "^3.4.3",
         "react-select": "^4.3.0",
         "react-twitter-embed": "3.0.3"
@@ -7618,23 +7617,35 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "4.1.17",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-4.1.17.tgz",
-      "integrity": "sha512-thx1wvKzblzbs0XaK2X0G1JuwIdARcoNOW7VVwjO8BUltzXPyONGAElLu6CiCScsOQRI7FIk/45YTFtJw5Yozw==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-5.6.0.tgz",
+      "integrity": "sha512-Y4FtwUU+LUWLKSzoT6Sq538qluvhpe6izdQK8/xZeVjQZ/ORKGfZzyhzcUxNfscqnfEa3dUOA47s+dwrSipdGA==",
       "license": "MIT",
       "dependencies": {
-        "framesync": "5.3.0",
+        "framesync": "6.0.1",
         "hey-listen": "^1.0.8",
-        "popmotion": "9.3.6",
-        "style-value-types": "4.1.4",
+        "popmotion": "11.0.3",
+        "react-merge-refs": "^1.1.0",
+        "react-use-measure": "^2.1.1",
+        "style-value-types": "5.0.0",
         "tslib": "^2.1.0"
       },
       "optionalDependencies": {
         "@emotion/is-prop-valid": "^0.8.2"
       },
       "peerDependencies": {
+        "@react-three/fiber": "*",
         "react": ">=16.8 || ^17.0.0",
-        "react-dom": ">=16.8 || ^17.0.0"
+        "react-dom": ">=16.8 || ^17.0.0",
+        "three": "^0.135.0"
+      },
+      "peerDependenciesMeta": {
+        "@react-three/fiber": {
+          "optional": true
+        },
+        "three": {
+          "optional": true
+        }
       }
     },
     "node_modules/framer-motion/node_modules/tslib": {
@@ -7644,9 +7655,9 @@
       "license": "0BSD"
     },
     "node_modules/framesync": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/framesync/-/framesync-5.3.0.tgz",
-      "integrity": "sha512-oc5m68HDO/tuK2blj7ZcdEBRx3p1PjrgHazL8GYEpvULhrtGIFbQArN6cQS2QhW8mitffaB+VYzMjDqBxxQeoA==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/framesync/-/framesync-6.0.1.tgz",
+      "integrity": "sha512-fUY88kXvGiIItgNC7wcTOl0SNRCVXMKSWW2Yzfmn7EKNc+MpCzcz9DhdHcdjbrtN3c6R4H5dTY2jiCpPdysEjA==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.1.0"
@@ -12118,14 +12129,14 @@
       }
     },
     "node_modules/popmotion": {
-      "version": "9.3.6",
-      "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-9.3.6.tgz",
-      "integrity": "sha512-ZTbXiu6zIggXzIliMi8LGxXBF5ST+wkpXGEjeTUDUOCdSQ356hij/xjeUdv0F8zCQNeqB1+PR5/BB+gC+QLAPw==",
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-11.0.3.tgz",
+      "integrity": "sha512-Y55FLdj3UxkR7Vl3s7Qr4e9m0onSnP8W7d/xQLsoJM40vs6UKHFdygs6SWryasTZYqugMjm3BepCF4CWXDiHgA==",
       "license": "MIT",
       "dependencies": {
-        "framesync": "5.3.0",
+        "framesync": "6.0.1",
         "hey-listen": "^1.0.8",
-        "style-value-types": "4.1.4",
+        "style-value-types": "5.0.0",
         "tslib": "^2.1.0"
       }
     },
@@ -14029,21 +14040,20 @@
         "react": "^0.14.7 || ^15.0.0 || ^16.0.0"
       }
     },
+    "node_modules/react-merge-refs": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/react-merge-refs/-/react-merge-refs-1.1.0.tgz",
+      "integrity": "sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
+      }
+    },
     "node_modules/react-proptype-conditional-require": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/react-proptype-conditional-require/-/react-proptype-conditional-require-1.0.4.tgz",
       "integrity": "sha1-acLVdB5t9eCPIw82u8KUTuEiJVU="
-    },
-    "node_modules/react-reveal": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/react-reveal/-/react-reveal-1.2.2.tgz",
-      "integrity": "sha512-JCv3fAoU6Z+Lcd8U48bwzm4pMZ79qsedSXYwpwt6lJNtj/v5nKJYZZbw3yhaQPPgYePo3Y0NOCoYOq/jcsisuw==",
-      "dependencies": {
-        "prop-types": "^15.5.10"
-      },
-      "peerDependencies": {
-        "react": "^15.3.0 || ^16.0.0"
-      }
     },
     "node_modules/react-scripts": {
       "version": "3.4.4",
@@ -14272,6 +14282,21 @@
         "prop-types": "^15.5.4",
         "react": "^15.0.0 || ^16.0.0",
         "react-dom": "^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/react-use-measure": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.1.7.tgz",
+      "integrity": "sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.13",
+        "react-dom": ">=16.13"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/read-pkg": {
@@ -16111,9 +16136,9 @@
       }
     },
     "node_modules/style-value-types": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-4.1.4.tgz",
-      "integrity": "sha512-LCJL6tB+vPSUoxgUBt9juXIlNJHtBMy8jkXzUJSBzeHWdBu6lhzHqCvLVkXFGsFIlNa2ln1sQHya/gzaFmB2Lg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-5.0.0.tgz",
+      "integrity": "sha512-08yq36Ikn4kx4YU6RD7jWEv27v4V+PUsOGa4n/as8Et3CuODMJQ00ENeAVXAeydX4Z2j1XHZF1K2sX4mGl18fA==",
       "license": "MIT",
       "dependencies": {
         "hey-listen": "^1.0.8",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "dependencies": {
     "colorthief": "^2.3.0",
-    "framer-motion": "^4.1.17",
+    "framer-motion": "^5.6.0",
     "gh-pages": "^2.2.0",
     "i18next": "^20.1.0",
     "react": "^16.10.2",
@@ -14,7 +14,6 @@
     "react-headroom": "^3.0.0",
     "react-i18next": "^11.8.12",
     "react-lottie": "^1.2.3",
-    "react-reveal": "^1.2.2",
     "react-scripts": "^3.4.3",
     "react-select": "^4.3.0",
     "react-twitter-embed": "3.0.3"

--- a/src/components/educationCard/EducationCard.js
+++ b/src/components/educationCard/EducationCard.js
@@ -1,14 +1,13 @@
 import React, {createRef, useContext} from "react";
-import {Fade, Slide} from "react-reveal";
+import {motion} from "framer-motion";
 import "./EducationCard.css";
 import StyleContext from "../../contexts/StyleContext";
-import {
-  useTranslation
-} from "react-i18next";
+import {useTranslation} from "react-i18next";
+import {defaultViewport, fadeIn, slideUp} from "../../utils/animations";
 export default function EducationCard({school}) {
   const imgRef = createRef();
 
-  const { t } = useTranslation('common');
+  const {t} = useTranslation("common");
   const GetDescBullets = ({descBullets}) => {
     return descBullets
       ? descBullets.map((item, i) => (
@@ -20,51 +19,52 @@ export default function EducationCard({school}) {
   };
   const {isDark} = useContext(StyleContext);
   return (
-    <div>
-      <Fade left duration={1000}>
-        <div className="education-card">
-          <div className="education-card-left">
-            <img
-              crossOrigin={"anonymous"}
-              ref={imgRef}
-              className="education-roundedimg"
-              src={school.logo}
-              alt={school.schoolName}
-            />
-          </div>
-          <div className="education-card-right">
-            <h5 className="education-text-school">{t(school.schoolName)}</h5>
+    <motion.div
+      initial="hidden"
+      whileInView="show"
+      viewport={defaultViewport}
+      variants={fadeIn}
+    >
+      <motion.div className="education-card" variants={slideUp}>
+        <div className="education-card-left">
+          <img
+            crossOrigin={"anonymous"}
+            ref={imgRef}
+            className="education-roundedimg"
+            src={school.logo}
+            alt={school.schoolName}
+          />
+        </div>
+        <div className="education-card-right">
+          <h5 className="education-text-school">{t(school.schoolName)}</h5>
 
-            <div className="education-text-details">
-              <h5
-                className={
-                  isDark
-                    ? "dark-mode education-text-subHeader"
-                    : "education-text-subHeader"
-                }
-              >
-                {t(school.subHeader)}
-              </h5>
-              <p
-                className={`${
-                  isDark ? "dark-mode" : ""
-                } education-text-duration`}
-              >
-                {school.duration}
-              </p>
-              <p className="education-text-desc">{school.desc}</p>
-              <div className="education-text-bullets">
-                <ul>
-                  <GetDescBullets descBullets={school.descBullets} />
-                </ul>
-              </div>
+          <div className="education-text-details">
+            <h5
+              className={
+                isDark
+                  ? "dark-mode education-text-subHeader"
+                  : "education-text-subHeader"
+              }
+            >
+              {t(school.subHeader)}
+            </h5>
+            <p
+              className={`${
+                isDark ? "dark-mode" : ""
+              } education-text-duration`}
+            >
+              {school.duration}
+            </p>
+            <p className="education-text-desc">{school.desc}</p>
+            <div className="education-text-bullets">
+              <ul>
+                <GetDescBullets descBullets={school.descBullets} />
+              </ul>
             </div>
           </div>
         </div>
-      </Fade>
-      <Slide left duration={2000}>
-        <div className="education-card-border"></div>
-      </Slide>
-    </div>
+      </motion.div>
+      <motion.div className="education-card-border" variants={slideUp}></motion.div>
+    </motion.div>
   );
 }

--- a/src/components/footer/Footer.js
+++ b/src/components/footer/Footer.js
@@ -1,24 +1,33 @@
 import React, {useContext} from "react";
+import {motion} from "framer-motion";
 import "./Footer.css";
-import {Fade} from "react-reveal";
 import emoji from "react-easy-emoji";
 import StyleContext from "../../contexts/StyleContext";
+import {defaultViewport, fadeIn, slideUp} from "../../utils/animations";
 
 export default function Footer() {
   const {isDark} = useContext(StyleContext);
   return (
-    <Fade bottom duration={1000} distance="5px">
-      <div className="footer-div">
-        <p className={isDark ? "dark-mode footer-text" : "footer-text"}>
-          {emoji("Made with ❤️ by Saad Pasta")}
-        </p>
-        <p className={isDark ? "dark-mode footer-text" : "footer-text"}>
-          Theme by{" "}
-          <a href="https://github.com/saadpasta/developerFolio">
-            developerFolio
-          </a>
-        </p>
-      </div>
-    </Fade>
+    <motion.footer
+      className="footer-div"
+      initial="hidden"
+      whileInView="show"
+      viewport={defaultViewport}
+      variants={fadeIn}
+    >
+      <motion.p
+        className={isDark ? "dark-mode footer-text" : "footer-text"}
+        variants={slideUp}
+      >
+        {emoji("Made with ❤️ by Saad Pasta")}
+      </motion.p>
+      <motion.p
+        className={isDark ? "dark-mode footer-text" : "footer-text"}
+        variants={slideUp}
+      >
+        Theme by{" "}
+        <a href="https://github.com/saadpasta/developerFolio">developerFolio</a>
+      </motion.p>
+    </motion.footer>
   );
 }

--- a/src/components/githubProfileCard/GithubProfileCard.js
+++ b/src/components/githubProfileCard/GithubProfileCard.js
@@ -1,67 +1,67 @@
-﻿import React from "react";
+import React from "react";
+import {motion} from "framer-motion";
 import "./GithubProfileCard.css";
 import SocialMedia from "../../components/socialMedia/SocialMedia";
 import {contactInfo} from "../../portfolio";
 import emoji from "react-easy-emoji";
-import {Fade} from "react-reveal";
-import {
-  useTranslation
-} from "react-i18next";
+import {useTranslation} from "react-i18next";
+import {defaultViewport, fadeIn, slideUp, stagger} from "../../utils/animations";
 
 export default function GithubProfileCard({prof}) {
-  const {
-    t
-  } = useTranslation('common');
+  const {t} = useTranslation("common");
   if (prof.hireable === true) {
     prof.hireable = "Yes";
   } else {
     prof.hireable = "No";
   }
   return (
-    <Fade bottom duration={1000} distance="20px">
-      <div className="main" id="contact">
-        <h1 className="prof-title">Reach Out to me!</h1>
-        <div className="row">
-          <div className="main-content-profile">
-            <div className="blog-header">
-              <p className="subTitle blog-subtitle">{t(contactInfo.subtitle)}</p>
-            </div>
-            <h2 className="bio-text">"{emoji(String(prof.bio))}"</h2>
-            {prof.location !== null && (
-              <div className="location-div">
-                <span className="desc-prof">
-                  <svg
-                    viewBox="0 0 12 16"
-                    version="1.1"
-                    width="20"
-                    height="18"
-                    aria-hidden="true"
-                  >
-                    <path
-                      fillRule="evenodd"
-                      d="M6 0C2.69 0 0 2.5 0 5.5 0 10.02 6 16 6 16s6-5.98 6-10.5C12 2.5 9.31 0 6 0zm0 14.55C4.14 12.52 1 8.44 1 5.5 1 3.02 3.25 1 6 1c1.34 0 2.61.48 3.56 1.36.92.86 1.44 1.97 1.44 3.14 0 2.94-3.14 7.02-5 9.05zM8 5.5c0 1.11-.89 2-2 2-1.11 0-2-.89-2-2 0-1.11.89-2 2-2 1.11 0 2 .89 2 2z"
-                    ></path>
-                  </svg>
-                  {prof.location}
-                </span>
-              </div>
-            )}
-            <div className="opp-div">
+    <motion.section
+      className="main"
+      id="contact"
+      initial="hidden"
+      whileInView="show"
+      viewport={defaultViewport}
+      variants={fadeIn}
+    >
+      <motion.h1 className="prof-title" variants={slideUp}>
+        Reach Out to me!
+      </motion.h1>
+      <motion.div className="row" variants={stagger(0.18, 0.12)}>
+        <motion.div className="main-content-profile" variants={slideUp}>
+          <div className="blog-header">
+            <p className="subTitle blog-subtitle">{t(contactInfo.subtitle)}</p>
+          </div>
+          <h2 className="bio-text">"{emoji(String(prof.bio))}"</h2>
+          {prof.location !== null && (
+            <div className="location-div">
               <span className="desc-prof">
-                Open for opportunities: {prof.hireable}
+                <svg
+                  viewBox="0 0 12 16"
+                  version="1.1"
+                  width="20"
+                  height="18"
+                  aria-hidden="true"
+                >
+                  <path
+                    fillRule="evenodd"
+                    d="M6 0C2.69 0 0 2.5 0 5.5 0 10.02 6 16 6 16s6-5.98 6-10.5C12 2.5 9.31 0 6 0zm0 14.55C4.14 12.52 1 8.44 1 5.5 1 3.02 3.25 1 6 1c1.34 0 2.61.48 3.56 1.36.92.86 1.44 1.97 1.44 3.14 0 2.94-3.14 7.02-5 9.05zM8 5.5c0 1.11-.89 2-2 2-1.11 0-2-.89-2-2 0-1.11.89-2 2-2 1.11 0 2 .89 2 2z"
+                  ></path>
+                </svg>
+                {prof.location}
               </span>
             </div>
-            <SocialMedia />
+          )}
+          <div className="opp-div">
+            <span className="desc-prof">
+              Open for opportunities: {prof.hireable}
+            </span>
           </div>
-          <div className="image-content-profile">
-            <img
-              src={prof.avatarUrl}
-              alt={prof.name}
-              className="profile-image"
-            />
-          </div>
-        </div>
-      </div>
-    </Fade>
+          <SocialMedia />
+        </motion.div>
+        <motion.div className="image-content-profile" variants={slideUp}>
+          <img src={prof.avatarUrl} alt={prof.name} className="profile-image" />
+        </motion.div>
+      </motion.div>
+    </motion.section>
   );
 }

--- a/src/components/githubRepoCard/GithubRepoCard.js
+++ b/src/components/githubRepoCard/GithubRepoCard.js
@@ -1,6 +1,7 @@
 import React from "react";
+import {motion} from "framer-motion";
 import "./GithubRepoCard.css";
-import {Fade} from "react-reveal";
+import {defaultViewport, fadeIn, slideUp} from "../../utils/animations";
 
 export default function GithubRepoCard({repo, isDark}) {
   function openRepoinNewTab(url) {
@@ -9,13 +10,18 @@ export default function GithubRepoCard({repo, isDark}) {
   }
 
   return (
-    <Fade bottom duration={1000} distance="20px">
-      <div>
-        <div
-          className={isDark ? "dark-card-mode repo-card-div" : "repo-card-div"}
-          key={repo.node.id}
-          onClick={() => openRepoinNewTab(repo.node.url)}
-        >
+    <motion.div
+      initial="hidden"
+      whileInView="show"
+      viewport={defaultViewport}
+      variants={fadeIn}
+    >
+      <motion.div
+        className={isDark ? "dark-card-mode repo-card-div" : "repo-card-div"}
+        key={repo.node.id}
+        onClick={() => openRepoinNewTab(repo.node.url)}
+        variants={slideUp}
+      >
           <div className="repo-name-div">
             <svg
               aria-hidden="true"
@@ -83,8 +89,7 @@ export default function GithubRepoCard({repo, isDark}) {
               <p>{repo.node.diskUsage} KB</p>
             </div>
           </div>
-        </div>
-      </div>
-    </Fade>
+      </motion.div>
+    </motion.div>
   );
 }

--- a/src/containers/StartupProjects/StartupProject.js
+++ b/src/containers/StartupProjects/StartupProject.js
@@ -1,94 +1,98 @@
 import React, {useContext} from "react";
+import {motion} from "framer-motion";
 import "./StartupProjects.css";
 import {bigProjects} from "../../portfolio";
-import {Fade} from "react-reveal";
 import StyleContext from "../../contexts/StyleContext";
-import {
-  useTranslation
-} from "react-i18next";
+import {useTranslation} from "react-i18next";
+import {defaultViewport, fadeIn, slideUp, stagger} from "../../utils/animations";
 
 export default function StartupProject() {
   function openProjectInNewWindow(url) {
     var win = window.open(url, "_blank");
     win.focus();
   }
-  const { t } = useTranslation('common');
+  const {t} = useTranslation("common");
   const {isDark} = useContext(StyleContext);
   if (!bigProjects.display) {
     return null;
   }
   return (
-    <Fade bottom duration={1000} distance="20px">
-      <div className="main" id="projects">
-        <div>
-          <h1 className="skills-heading">{t(bigProjects.title)}</h1>
-          <p
-            className={
-              isDark
-                ? "dark-mode project-subtitle"
-                : "subTitle project-subtitle"
-            }
-          >
-            {t(bigProjects.subtitle)}
-          </p>
+    <motion.section
+      className="main"
+      id="projects"
+      initial="hidden"
+      whileInView="show"
+      viewport={defaultViewport}
+      variants={fadeIn}
+    >
+      <motion.div variants={stagger(0.18, 0.12)}>
+        <motion.h1 className="skills-heading" variants={slideUp}>
+          {t(bigProjects.title)}
+        </motion.h1>
+        <motion.p
+          className={
+            isDark ? "dark-mode project-subtitle" : "subTitle project-subtitle"
+          }
+          variants={slideUp}
+        >
+          {t(bigProjects.subtitle)}
+        </motion.p>
 
-          <div className="projects-container">
-            {bigProjects.projects.map((project, i) => {
-              return (
-                <div
-                  key={i}
-                  className={
-                    isDark
-                      ? "dark-mode project-card project-card-dark"
-                      : "project-card project-card-light"
-                  }
-                >
-                  {project.image ? (
-                    <div className="project-image">
-                      <img
-                        src={project.image}
-                        alt={t(project.projectName)}
-                        className="card-image"
-                      ></img>
+        <motion.div className="projects-container" variants={stagger(0.14, 0.1)}>
+          {bigProjects.projects.map((project, i) => {
+            return (
+              <motion.div
+                key={i}
+                className={
+                  isDark
+                    ? "dark-mode project-card project-card-dark"
+                    : "project-card project-card-light"
+                }
+                variants={slideUp}
+              >
+                {project.image ? (
+                  <div className="project-image">
+                    <img
+                      src={project.image}
+                      alt={t(project.projectName)}
+                      className="card-image"
+                    ></img>
+                  </div>
+                ) : null}
+                <div className="project-detail">
+                  <h5 className={isDark ? "dark-mode card-title" : "card-title"}>
+                    {t(project.projectName)}
+                  </h5>
+                  <p
+                    className={
+                      isDark ? "dark-mode card-subtitle" : "card-subtitle"
+                    }
+                  >
+                    {t(project.projectDesc)}
+                  </p>
+                  {project.footerLink ? (
+                    <div className="project-card-footer">
+                      {project.footerLink.map((link, linkIndex) => {
+                        return (
+                          <span
+                            key={linkIndex}
+                            className={
+                              isDark ? "dark-mode project-tag" : "project-tag"
+                            }
+                            onClick={() => openProjectInNewWindow(link.url)}
+                          >
+                            {link.name}
+                          </span>
+                        );
+                      })}
                     </div>
                   ) : null}
-                  <div className="project-detail">
-                    <h5
-                      className={isDark ? "dark-mode card-title" : "card-title"}
-                    >
-                      {t(project.projectName)}
-                    </h5>
-                    <p
-                      className={
-                        isDark ? "dark-mode card-subtitle" : "card-subtitle"
-                      }
-                    >
-                      {t(project.projectDesc)}
-                    </p>
-                    {project.footerLink ? (
-                      <div className="project-card-footer">
-                        {project.footerLink.map((link, i) => {
-                          return (
-                            <span
-                              key={i}
-                              className={
-                                isDark ? "dark-mode project-tag" : "project-tag"
-                              }
-                              onClick={() => openProjectInNewWindow(link.url)}
-                            >
-                              {link.name}
-                            </span>
-                          );
-                        })}
-                      </div>
-                    ) : null}
-                  </div>
                 </div>
-              );
-            })}
-          </div>
-        </div>
-      </div>
-    </Fade>
+              </motion.div>
+            );
+          })}
+        </motion.div>
+      </motion.div>
+    </motion.section>
   );
 }

--- a/src/containers/achievement/Achievement.js
+++ b/src/containers/achievement/Achievement.js
@@ -1,43 +1,50 @@
 import React, {useContext} from "react";
+import {motion} from "framer-motion";
 import "./Achievement.css";
 import AchievementCard from "../../components/achievementCard/AchievementCard";
 import {achievementSection} from "../../portfolio";
-import {Fade} from "react-reveal";
 import StyleContext from "../../contexts/StyleContext";
+import {defaultViewport, fadeIn, slideUp, stagger} from "../../utils/animations";
 export default function Achievement() {
   const {isDark} = useContext(StyleContext);
   if (!achievementSection.display) {
     return null;
   }
   return (
-    <Fade bottom duration={1000} distance="20px">
-      <div className="main" id="achievements">
-        <div className="achievement-main-div">
-          <div className="achievement-header">
-            <h1
-              className={
-                isDark
-                  ? "dark-mode heading achievement-heading"
-                  : "heading achievement-heading"
-              }
-            >
-              {achievementSection.title}
-            </h1>
-            <p
-              className={
-                isDark
-                  ? "dark-mode subTitle achievement-subtitle"
-                  : "subTitle achievement-subtitle"
-              }
-            >
-              {achievementSection.subtitle}
-            </p>
-          </div>
-          <div className="achievement-cards-div">
-            {achievementSection.achievementsCards.map((card, i) => {
-              return (
+    <motion.section
+      className="main"
+      id="achievements"
+      initial="hidden"
+      whileInView="show"
+      viewport={defaultViewport}
+      variants={fadeIn}
+    >
+      <motion.div className="achievement-main-div" variants={stagger(0.18, 0.12)}>
+        <motion.div className="achievement-header" variants={slideUp}>
+          <h1
+            className={
+              isDark
+                ? "dark-mode heading achievement-heading"
+                : "heading achievement-heading"
+            }
+          >
+            {achievementSection.title}
+          </h1>
+          <p
+            className={
+              isDark
+                ? "dark-mode subTitle achievement-subtitle"
+                : "subTitle achievement-subtitle"
+            }
+          >
+            {achievementSection.subtitle}
+          </p>
+        </motion.div>
+        <motion.div className="achievement-cards-div" variants={stagger(0.12, 0.1)}>
+          {achievementSection.achievementsCards.map((card, i) => {
+            return (
+              <motion.div key={i} variants={slideUp}>
                 <AchievementCard
-                  key={i}
                   isDark={isDark}
                   cardInfo={{
                     title: card.title,
@@ -46,11 +53,11 @@ export default function Achievement() {
                     footer: card.footerLink
                   }}
                 />
-              );
-            })}
-          </div>
-        </div>
-      </div>
-    </Fade>
+              </motion.div>
+            );
+          })}
+        </motion.div>
+      </motion.div>
+    </motion.section>
   );
 }

--- a/src/containers/blogs/Blogs.js
+++ b/src/containers/blogs/Blogs.js
@@ -1,33 +1,40 @@
 import React, {useContext} from "react";
+import {motion} from "framer-motion";
 import "./Blog.css";
 import BlogCard from "../../components/blogCard/BlogCard";
 import {blogSection} from "../../portfolio";
-import {Fade} from "react-reveal";
 import StyleContext from "../../contexts/StyleContext";
+import {defaultViewport, fadeIn, slideUp, stagger} from "../../utils/animations";
 export default function Blogs() {
   const {isDark} = useContext(StyleContext);
   if (!blogSection.display) {
     return null;
   }
   return (
-    <Fade bottom duration={1000} distance="20px">
-      <div className="main" id="blogs">
-        <div className="blog-header">
-          <h1 className="blog-header-text">{blogSection.title}</h1>
-          <p
-            className={
-              isDark ? "dark-mode blog-subtitle" : "subTitle blog-subtitle"
-            }
-          >
-            {blogSection.subtitle}
-          </p>
-        </div>
-        <div className="blog-main-div">
-          <div className="blog-text-div">
-            {blogSection.blogs.map((blog, i) => {
-              return (
+    <motion.section
+      className="main"
+      id="blogs"
+      initial="hidden"
+      whileInView="show"
+      viewport={defaultViewport}
+      variants={fadeIn}
+    >
+      <motion.div className="blog-header" variants={slideUp}>
+        <h1 className="blog-header-text">{blogSection.title}</h1>
+        <p
+          className={
+            isDark ? "dark-mode blog-subtitle" : "subTitle blog-subtitle"
+          }
+        >
+          {blogSection.subtitle}
+        </p>
+      </motion.div>
+      <motion.div className="blog-main-div" variants={stagger(0.16, 0.12)}>
+        <motion.div className="blog-text-div" variants={stagger(0.12, 0.1)}>
+          {blogSection.blogs.map((blog, i) => {
+            return (
+              <motion.div key={i} variants={slideUp}>
                 <BlogCard
-                  key={i}
                   isDark={isDark}
                   blog={{
                     url: blog.url,
@@ -36,11 +43,11 @@ export default function Blogs() {
                     description: blog.description
                   }}
                 />
-              );
-            })}
-          </div>
-        </div>
-      </div>
-    </Fade>
+              </motion.div>
+            );
+          })}
+        </motion.div>
+      </motion.div>
+    </motion.section>
   );
 }

--- a/src/containers/contact/Contact.js
+++ b/src/containers/contact/Contact.js
@@ -1,68 +1,70 @@
 import React, {useContext} from "react";
+import {motion} from "framer-motion";
 import "./Contact.css";
 import SocialMedia from "../../components/socialMedia/SocialMedia";
 import {illustration, contactInfo} from "../../portfolio";
-import {Fade} from "react-reveal";
 import email from "../../assets/lottie/email";
 import DisplayLottie from "../../components/displayLottie/DisplayLottie";
 import StyleContext from "../../contexts/StyleContext";
 import emoji from "react-easy-emoji";
-import {
-  useTranslation
-} from "react-i18next";
+import {useTranslation} from "react-i18next";
+import {defaultViewport, fadeIn, slideUp, stagger} from "../../utils/animations";
 export default function Contact() {
   const {isDark} = useContext(StyleContext);
-  const {
-    t
-  } = useTranslation('common');
+  const {t} = useTranslation("common");
   return (
-    <Fade bottom duration={1000} distance="20px">
-      <div className="main contact-margin-top" id="contact">
-        <div className="contact-div-main">
-          <div className="contact-header">
-            <h1 className="heading contact-title">{emoji(t(contactInfo.title))}</h1>
-            <p
-              className={
-                isDark
-                  ? "dark-mode contact-subtitle"
-                  : "subTitle contact-subtitle"
-              }
+    <motion.section
+      className="main contact-margin-top"
+      id="contact"
+      initial="hidden"
+      whileInView="show"
+      viewport={defaultViewport}
+      variants={fadeIn}
+    >
+      <motion.div className="contact-div-main" variants={stagger(0.18, 0.12)}>
+        <motion.div className="contact-header" variants={slideUp}>
+          <h1 className="heading contact-title">{emoji(t(contactInfo.title))}</h1>
+          <p
+            className={
+              isDark
+                ? "dark-mode contact-subtitle"
+                : "subTitle contact-subtitle"
+            }
+          >
+            {t(contactInfo.subtitle)}
+          </p>
+          <div
+            className={
+              isDark ? "dark-mode contact-text-div" : "contact-text-div"
+            }
+          >
+            {/* <a className="contact-detail" href={"tel:" + contactInfo.number}>
+              {contactInfo.number}
+            </a>
+            <br />
+            <br /> */}
+            <a
+              className="contact-detail-email"
+              href={"mailto:" + contactInfo.email_address}
             >
-              {t(contactInfo.subtitle)}
-            </p>
-            <div
-              className={
-                isDark ? "dark-mode contact-text-div" : "contact-text-div"
-              }
-            >
-              {/* <a className="contact-detail" href={"tel:" + contactInfo.number}>
-                {contactInfo.number}
-              </a>
-              <br />
-              <br /> */}
-              <a
-                className="contact-detail-email"
-                href={"mailto:" + contactInfo.email_address}
-              >
-                {contactInfo.email_address}
-              </a>
-              <br />
-              <br />
-              <SocialMedia />
-            </div>
+              {contactInfo.email_address}
+            </a>
+            <br />
+            <br />
+            <SocialMedia />
           </div>
-          <div className="contact-image-div">
-            {illustration.animated ? (
-              <DisplayLottie animationData={email} />
-            ) : (
-              <img
-                alt="Man working"
-                src={require("../../assets/images/contactMailDark.svg")}
-              ></img>
-            )}
-          </div>
-        </div>
-      </div>
-    </Fade>
+        </motion.div>
+        <motion.div className="contact-image-div" variants={slideUp}>
+          {illustration.animated ? (
+            <DisplayLottie animationData={email} />
+          ) : (
+            <img
+              alt="Man working"
+              src={require("../../assets/images/contactMailDark.svg")}
+            ></img>
+          )}
+        </motion.div>
+      </motion.div>
+    </motion.section>
   );
 }

--- a/src/containers/greeting/Greeting.js
+++ b/src/containers/greeting/Greeting.js
@@ -7,44 +7,10 @@ import Button from "../../components/button/Button";
 import DisplayLottie from "../../components/displayLottie/DisplayLottie";
 
 import landingPerson from "../../assets/lottie/landingPerson.json";
-import { greeting } from "../../portfolio";
+import {greeting} from "../../portfolio";
 import StyleContext from "../../contexts/StyleContext";
 import {useTranslation} from "react-i18next";
-
-const containerVariants = {
-  hidden: {opacity: 0, y: 40},
-  visible: {
-    opacity: 1,
-    y: 0,
-    transition: {
-      duration: 0.8,
-      ease: [0.22, 1, 0.36, 1],
-      when: "beforeChildren",
-      staggerChildren: 0.15
-    }
-  }
-};
-
-const childVariants = {
-  hidden: {opacity: 0, y: 20},
-  visible: {
-    opacity: 1,
-    y: 0,
-    transition: {
-      duration: 0.6,
-      ease: [0.33, 1, 0.68, 1]
-    }
-  }
-};
-
-const imageVariants = {
-  hidden: {opacity: 0, y: 32},
-  visible: {
-    opacity: 1,
-    y: 0,
-    transition: {duration: 0.9, ease: [0.22, 1, 0.36, 1]}
-  }
-};
+import {defaultViewport, fadeIn, slideUp, stagger} from "../../utils/animations";
 
 export default function Greeting() {
   const {isDark} = useContext(StyleContext);
@@ -59,12 +25,13 @@ export default function Greeting() {
       id="greeting"
       className="greet-main"
       initial="hidden"
-      animate="visible"
-      variants={containerVariants}
+      whileInView="show"
+      viewport={defaultViewport}
+      variants={fadeIn}
     >
-      <div className="greeting-wrapper">
-        <motion.div className="greeting-text-card" variants={childVariants}>
-          <motion.h1 className="greeting-title" variants={childVariants}>
+      <motion.div className="greeting-wrapper" variants={stagger(0.2, 0.15)}>
+        <motion.div className="greeting-text-card" variants={stagger(0.14, 0.08)}>
+          <motion.h1 className="greeting-title" variants={slideUp}>
             {t(greeting.title)}{" "}
             <motion.span
               className="wave-emoji"
@@ -76,13 +43,13 @@ export default function Greeting() {
               {emoji("👋")}
             </motion.span>
           </motion.h1>
-          <motion.p className="greeting-subtitle" variants={childVariants}>
+          <motion.p className="greeting-subtitle" variants={slideUp}>
             {t(greeting.subTitle)}
           </motion.p>
-          <motion.div variants={childVariants}>
+          <motion.div variants={slideUp}>
             <SocialMedia />
           </motion.div>
-          <motion.div className="button-greeting-div" variants={childVariants}>
+          <motion.div className="button-greeting-div" variants={slideUp}>
             <Button text="Contact me" href="#contact" />
             {
               // TODO: AGREGAR CV
@@ -97,7 +64,7 @@ export default function Greeting() {
 
         <motion.div
           className="greeting-visual"
-          variants={childVariants}
+          variants={slideUp}
           whileHover={{scale: 1.03, rotate: -1}}
           whileTap={{scale: 0.97}}
         >
@@ -110,12 +77,12 @@ export default function Greeting() {
               src={require("../../assets/images/profile_photo.png")}
               alt="Profile"
               loading="lazy"
-              variants={imageVariants}
+              variants={fadeIn}
             />
             <div className={`greeting-glass ${isDark ? "greeting-glass-dark" : ""}`} />
           </div>
         </motion.div>
-      </div>
+      </motion.div>
     </motion.section>
   );
 }

--- a/src/containers/podcast/Podcast.js
+++ b/src/containers/podcast/Podcast.js
@@ -1,8 +1,9 @@
 import React, {useContext} from "react";
+import {motion} from "framer-motion";
 import "./Podcast.css";
 import {podcastSection} from "../../portfolio";
-import {Fade} from "react-reveal";
 import StyleContext from "../../contexts/StyleContext";
+import {defaultViewport, fadeIn, slideUp, stagger} from "../../utils/animations";
 
 export default function Podcast() {
   const {isDark} = useContext(StyleContext);
@@ -10,36 +11,40 @@ export default function Podcast() {
     return null;
   }
   return (
-    <Fade bottom duration={1000} distance="20px">
-      <div className="main">
-        <div className="podcast-header">
-          <h1 className="podcast-header-title">{podcastSection.title}</h1>
-          <p
-            className={
-              isDark
-                ? "dark-mode podcast-header-subtitle"
-                : "subTitle podcast-header-subtitle"
-            }
-          >
-            {podcastSection.subtitle}
-          </p>
-        </div>
-        <div className="podcast-main-div">
-          {podcastSection.podcast.map((podcastLink, i) => {
-            return (
-              <div key={i}>
-                <iframe
-                  className="podcast"
-                  src={podcastLink}
-                  frameBorder="0"
-                  scrolling="no"
-                  title="Podcast"
-                ></iframe>
-              </div>
-            );
-          })}
-        </div>
-      </div>
-    </Fade>
+    <motion.section
+      className="main"
+      initial="hidden"
+      whileInView="show"
+      viewport={defaultViewport}
+      variants={fadeIn}
+    >
+      <motion.div className="podcast-header" variants={slideUp}>
+        <h1 className="podcast-header-title">{podcastSection.title}</h1>
+        <p
+          className={
+            isDark
+              ? "dark-mode podcast-header-subtitle"
+              : "subTitle podcast-header-subtitle"
+          }
+        >
+          {podcastSection.subtitle}
+        </p>
+      </motion.div>
+      <motion.div className="podcast-main-div" variants={stagger(0.16, 0.12)}>
+        {podcastSection.podcast.map((podcastLink, i) => {
+          return (
+            <motion.div key={i} variants={slideUp}>
+              <iframe
+                className="podcast"
+                src={podcastLink}
+                frameBorder="0"
+                scrolling="no"
+                title="Podcast"
+              ></iframe>
+            </motion.div>
+          );
+        })}
+      </motion.div>
+    </motion.section>
   );
 }

--- a/src/containers/skillProgress/skillProgress.js
+++ b/src/containers/skillProgress/skillProgress.js
@@ -1,53 +1,61 @@
 import React from "react";
+import {motion} from "framer-motion";
 import "./Progress.css";
 import {illustration, techStack} from "../../portfolio";
-import {Fade} from "react-reveal";
 import Build from "../../assets/lottie/build";
 import DisplayLottie from "../../components/displayLottie/DisplayLottie";
-import {
-  useTranslation
-} from "react-i18next";
+import {useTranslation} from "react-i18next";
+import {defaultViewport, fadeIn, slideUp, stagger} from "../../utils/animations";
 export default function StackProgress() {
-   const {
-     t
-   } = useTranslation('common');
+  const {t} = useTranslation("common");
   if (techStack.viewSkillBars) {
     return (
-      <Fade bottom duration={1000} distance="20px">
-        <div id="proficiency" className="skills-container">
-          <div className="skills-bar">
-            <h1 className="skills-heading">{t('skillProgress.skillProgressTitle')}</h1>
-            {techStack.experience.map((exp, i) => {
-              const progressStyle = {
-                width: exp.progressPercentage
-              };
-              if(exp.Section){
-                return ( <h2 style={{marginBottom: 0, marginTop: 40, textDecorationLine: "underline"}}>{t(exp.Title)}</h2> );
-              }else{
-                return (
-                  <div key={i} className="skill">
-                    <p>{exp.Stack}</p>
-                    <div className="meter">
-                      <span style={progressStyle}></span>
-                    </div>
-                  </div>
-                );
-              }
+      <motion.section
+        id="proficiency"
+        className="skills-container"
+        initial="hidden"
+        whileInView="show"
+        viewport={defaultViewport}
+        variants={fadeIn}
+      >
+        <motion.div className="skills-bar" variants={stagger(0.12, 0.1)}>
+          <motion.h1 className="skills-heading" variants={slideUp}>
+            {t("skillProgress.skillProgressTitle")}
+          </motion.h1>
+          {techStack.experience.map((exp, i) => {
+            const progressStyle = {
+              width: exp.progressPercentage
+            };
+            if (exp.Section) {
+              return (
+                <motion.h2
+                  key={`${exp.Title}-${i}`}
+                  style={{marginBottom: 0, marginTop: 40, textDecorationLine: "underline"}}
+                  variants={slideUp}
+                >
+                  {t(exp.Title)}
+                </motion.h2>
+              );
+            }
+            return (
+              <motion.div key={i} className="skill" variants={slideUp}>
+                <p>{exp.Stack}</p>
+                <div className="meter">
+                  <span style={progressStyle}></span>
+                </div>
+              </motion.div>
+            );
           })}
-          </div>
+        </motion.div>
 
-          <div className="skills-image">
-            {illustration.animated ? (
-              <DisplayLottie animationData={Build} />
-            ) : (
-              <img
-                alt="Skills"
-                src={require("../../assets/images/skill.svg")}
-              />
-            )}
-          </div>
-        </div>
-      </Fade>
+        <motion.div className="skills-image" variants={slideUp}>
+          {illustration.animated ? (
+            <DisplayLottie animationData={Build} />
+          ) : (
+            <img alt="Skills" src={require("../../assets/images/skill.svg")} />
+          )}
+        </motion.div>
+      </motion.section>
     );
   }
   return null;

--- a/src/containers/skills/Skills.js
+++ b/src/containers/skills/Skills.js
@@ -1,77 +1,73 @@
 import React, {useContext} from "react";
+import {motion} from "framer-motion";
 import "./Skills.css";
 import SoftwareSkill from "../../components/softwareSkills/SoftwareSkill";
 import {illustration, skillsSection} from "../../portfolio";
-import {Fade} from "react-reveal";
 import codingPerson from "../../assets/lottie/codingPerson";
 import DisplayLottie from "../../components/displayLottie/DisplayLottie";
 import StyleContext from "../../contexts/StyleContext";
-import {
-  useTranslation
-} from "react-i18next";
+import {useTranslation} from "react-i18next";
 import emoji from "react-easy-emoji";
+import {defaultViewport, fadeIn, slideUp, stagger} from "../../utils/animations";
 
 export default function Skills() {
   const {isDark} = useContext(StyleContext);
-  const {
-    t
-  } = useTranslation('common');
+  const {t} = useTranslation("common");
   if (!skillsSection.display) {
     return null;
   }
   return (
-    <div className={isDark ? "dark-mode main" : "main"} id="skills">
-      <div className="skills-main-div">
-        <Fade left duration={1000}>
-          <div className="skills-image-div">
-            {illustration.animated ? (
-              <DisplayLottie animationData={codingPerson} />
-            ) : (
-              <img
-                alt="Man Working"
-                src={require("../../assets/images/developerActivity.svg")}
-              ></img>
-            )}
+    <motion.section
+      className={isDark ? "dark-mode main" : "main"}
+      id="skills"
+      initial="hidden"
+      whileInView="show"
+      viewport={defaultViewport}
+      variants={fadeIn}
+    >
+      <motion.div className="skills-main-div" variants={stagger(0.18, 0.12)}>
+        <motion.div className="skills-image-div" variants={slideUp}>
+          {illustration.animated ? (
+            <DisplayLottie animationData={codingPerson} />
+          ) : (
+            <img
+              alt="Man Working"
+              src={require("../../assets/images/developerActivity.svg")}
+            ></img>
+          )}
+        </motion.div>
+        <motion.div className="skills-text-div" variants={slideUp}>
+          <h1 className={isDark ? "dark-mode skills-heading" : "skills-heading"}>
+            {t(skillsSection.title)}{" "}
+          </h1>
+          <p
+            className={
+              isDark
+                ? "dark-mode subTitle skills-text-subtitle"
+                : "subTitle skills-text-subtitle"
+            }
+          >
+            {t(skillsSection.subTitle)}
+          </p>
+          <SoftwareSkill />
+          <div>
+            {skillsSection.skills.map((skills, i) => {
+              return (
+                <p
+                  key={i}
+                  className={
+                    isDark
+                      ? "dark-mode subTitle skills-text"
+                      : "subTitle skills-text"
+                  }
+                >
+                  {emoji("- " + t(skills))}
+                </p>
+              );
+            })}
           </div>
-        </Fade>
-        <Fade right duration={1000}>
-          <div className="skills-text-div">
-            <h1
-              className={isDark ? "dark-mode skills-heading" : "skills-heading"}
-            >
-              {t(skillsSection.title)}{" "}
-            </h1>
-            <p
-              className={
-                isDark
-                  ? "dark-mode subTitle skills-text-subtitle"
-                  : "subTitle skills-text-subtitle"
-              }
-            >
-              {t(skillsSection.subTitle)}
-            </p>
-            <SoftwareSkill />
-            <div>
-              {skillsSection.skills.map((skills, i) => {
-                return (
-                  <p
-                    key={i}
-                    className={
-                      isDark
-                        ? "dark-mode subTitle skills-text"
-                        : "subTitle skills-text"
-                    }
-                  >
-                    {
-                      emoji("- "+ t(skills))
-                    }
-                  </p>
-                );
-              })}
-            </div>
-          </div>
-        </Fade>
-      </div>
-    </div>
+        </motion.div>
+      </motion.div>
+    </motion.section>
   );
 }

--- a/src/containers/talks/Talks.js
+++ b/src/containers/talks/Talks.js
@@ -1,9 +1,10 @@
 import React, {useContext} from "react";
+import {motion} from "framer-motion";
 import "./Talks.css";
 import TalkCard from "../../components/talkCard/TalkCard";
 import {talkSection} from "../../portfolio";
-import {Fade} from "react-reveal";
 import StyleContext from "../../contexts/StyleContext";
+import {defaultViewport, fadeIn, slideUp, stagger} from "../../utils/animations";
 
 export default function Talks() {
   const {isDark} = useContext(StyleContext);
@@ -11,23 +12,32 @@ export default function Talks() {
     return null;
   }
   return (
-    <Fade bottom duration={1000} distance="20px">
-      <div className="main" id="talks">
-        <div className="talk-header">
-          <h1 className="talk-header-title">{talkSection.title}</h1>
-          <p
-            className={
-              isDark
-                ? "dark-mode talk-header-subtitle"
-                : "subTitle talk-header-subtitle"
-            }
-          >
-            {talkSection.subtitle}
-          </p>
-          {talkSection.talks.map((talk, i) => {
-            return (
+    <motion.section
+      className="main"
+      id="talks"
+      initial="hidden"
+      whileInView="show"
+      viewport={defaultViewport}
+      variants={fadeIn}
+    >
+      <motion.div className="talk-header" variants={stagger(0.16, 0.12)}>
+        <motion.h1 className="talk-header-title" variants={slideUp}>
+          {talkSection.title}
+        </motion.h1>
+        <motion.p
+          className={
+            isDark
+              ? "dark-mode talk-header-subtitle"
+              : "subTitle talk-header-subtitle"
+          }
+          variants={slideUp}
+        >
+          {talkSection.subtitle}
+        </motion.p>
+        {talkSection.talks.map((talk, i) => {
+          return (
+            <motion.div key={i} variants={slideUp}>
               <TalkCard
-                key={i}
                 talkDetails={{
                   title: talk.title,
                   subtitle: talk.subtitle,
@@ -37,10 +47,10 @@ export default function Talks() {
                   isDark
                 }}
               />
-            );
-          })}
-        </div>
-      </div>
-    </Fade>
+            </motion.div>
+          );
+        })}
+      </motion.div>
+    </motion.section>
   );
 }

--- a/src/containers/workExperience/WorkExperience.js
+++ b/src/containers/workExperience/WorkExperience.js
@@ -1,27 +1,35 @@
 import React, {useContext} from "react";
+import {motion} from "framer-motion";
 import "./WorkExperience.css";
 import ExperienceCard from "../../components/experienceCard/ExperienceCard";
 import {workExperiences} from "../../portfolio";
-import {Fade} from "react-reveal";
 import StyleContext from "../../contexts/StyleContext";
-import {
-  useTranslation
-} from "react-i18next";
+import {useTranslation} from "react-i18next";
+import {defaultViewport, fadeIn, slideUp, stagger} from "../../utils/animations";
 export default function WorkExperience() {
   const {isDark} = useContext(StyleContext);
   const { t } = useTranslation('common');
   if (workExperiences.display) {
     return (
-      <div id="experience">
-        <Fade bottom duration={1000} distance="20px">
-          <div className="experience-container" id="workExperience">
-            <div>
-              <h1 className="experience-heading">{t('header.experiences')}</h1>
-              <div className="experience-cards-div">
-                {workExperiences.experience.map((card, i) => {
-                  return (
+      <motion.section
+        id="experience"
+        initial="hidden"
+        whileInView="show"
+        viewport={defaultViewport}
+        variants={fadeIn}
+      >
+        <motion.div
+          className="experience-container"
+          id="workExperience"
+          variants={stagger(0.18, 0.12)}
+        >
+          <motion.div variants={slideUp}>
+            <h1 className="experience-heading">{t("header.experiences")}</h1>
+            <motion.div className="experience-cards-div" variants={stagger(0.12, 0.1)}>
+              {workExperiences.experience.map((card, i) => {
+                return (
+                  <motion.div key={i} variants={slideUp}>
                     <ExperienceCard
-                      key={i}
                       isDark={isDark}
                       cardInfo={{
                         company: card.company,
@@ -33,13 +41,13 @@ export default function WorkExperience() {
                         descBullets: card.descBullets
                       }}
                     />
-                  );
-                })}
-              </div>
-            </div>
-          </div>
-        </Fade>
-      </div>
+                  </motion.div>
+                );
+              })}
+            </motion.div>
+          </motion.div>
+        </motion.div>
+      </motion.section>
     );
   }
   return null;

--- a/src/utils/animations.js
+++ b/src/utils/animations.js
@@ -1,0 +1,35 @@
+export const fadeIn = {
+  hidden: {opacity: 0},
+  show: {
+    opacity: 1,
+    transition: {
+      duration: 0.6,
+      ease: [0.33, 1, 0.68, 1]
+    }
+  }
+};
+
+export const slideUp = {
+  hidden: {opacity: 0, y: 40},
+  show: {
+    opacity: 1,
+    y: 0,
+    transition: {
+      duration: 0.7,
+      ease: [0.22, 1, 0.36, 1]
+    }
+  }
+};
+
+export const stagger = (staggerChildren = 0.16, delayChildren = 0.08) => ({
+  hidden: {},
+  show: {
+    transition: {
+      when: "beforeChildren",
+      staggerChildren,
+      delayChildren
+    }
+  }
+});
+
+export const defaultViewport = {once: true, amount: 0.25};


### PR DESCRIPTION
## Summary
- replace the legacy react-reveal dependency with framer-motion and shared animation variants
- update hero, skills, experience, contact, and supporting cards/sections to drive animations via motion components and scroll triggers
- centralize reusable fade, slide, and stagger variants for consistent transitions across the app

## Testing
- npm run build *(fails: requires Github username environment variable for fetch.js)*

------
https://chatgpt.com/codex/tasks/task_e_68d961e7a5c4832a987d9321a8580212